### PR TITLE
Wait 1 second before start (fix/workaround for UM425I)

### DIFF
--- a/asus_touchpad_numpad.service
+++ b/asus_touchpad_numpad.service
@@ -8,6 +8,7 @@ Type=simple
 ExecStart=/usr/bin/python3 /usr/bin/asus_touchpad_numpad.py
 StandardInput=tty-force
 TimeoutSec=5
+ExecStartPre=/bin/sleep 1
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Related: https://github.com/mohamed-badaoui/asus-touchpad-numpad-driver/issues/18

The driver originally didn't work for my 14" Zenbook UM425I (Arch Linux), and I kept getting an OSError from the script on boot. I found that delaying the start by a second fixed it for me. I also had to change this line

https://github.com/mohamed-badaoui/asus-touchpad-numpad-driver/blob/ea244caa146e9ca451aa9b6ff315fcd9a3dfa42d/touchpad_numpad_symbols.py#L191

from `y < 0.05` to `y < 0.15`