### PR TITLE
Make device extraction regex more robust.

### DIFF
--- a/asus_touchpad.py
+++ b/asus_touchpad.py
@@ -29,7 +29,7 @@ while tries > 0:
             if touchpad_detected == 1:
                 if "S: " in line:
                     # search device id 
-                    device_id=re.sub(r".*i2c-([^/])/.*$", r'\1', line).replace("\n", "")
+                    device_id=re.sub(r".*i2c-(\d+)/.*$", r'\1', line).replace("\n", "")
 
                 if "H: " in line:
                     touchpad = line.split("event")[1]


### PR DESCRIPTION
On my UX325EA the device id extraction fails, because the i2c device id has more than one character. This is the string against which the extraction regex is run:
`'S: Sysfs=/devices/pci0000:00/0000:00:15.1/i2c_designware.1/i2c-15/i2c-ASUE140A:00/0018:04F3:3134.0001/input/input13'
`

The fix assumes that device_id is a numeric value. This should be safe, as a check for this is done later.

My Device:
> [root@zenbook ~]# dmidecode | grep "Product Name"
	Product Name: ZenBook UX325EA_UX325EA
	Product Name: UX325EA

