### PR TITLE
Add UM325UA

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This python driver has been tested and works fine for these asus versions at the
 - UX363JA (with % and = symbols)
 - UX333FA (without extra symbols)
 - UX325EA (with % and = symbols)
+- UM325UA (with % and = symbols)
 - X412DA (without extra symbols)
 - UX581L (with % and = symbols)
 


### PR DESCRIPTION
Just confirming this also works on a UM325UA model. Thank you for making this!

Furthermore, the top right corner button also works so I've disabled the F8 trigger on [this fork](https://github.com/AdrianSkar/asus-touchpad-numpad-driver).