### PR TITLE
Don't continue processing if numlock key hit

### DIFF
--- a/asus_touchpad.py
+++ b/asus_touchpad.py
@@ -255,6 +255,7 @@ while True:
                     activate_numlock(brightness)
                 else:
                     deactivate_numlock()
+                continue
 
             # Check if caclulator was hit #
             elif (x < 0.06 * maxx) and (y < 0.07 * maxy):


### PR DESCRIPTION
This was needed for me on ASUS Zenbook 14X OLED UX5401EA-KN141T
Without this I get an equals sign input with numlock press.
using m433ia qwerty layout, arch linux