### PR TITLE
Ignore touches above numpad in the top_offset

### DIFF
--- a/asus_touchpad.py
+++ b/asus_touchpad.py
@@ -271,6 +271,9 @@ while True:
             # else numpad mode is activated
             col = math.floor(model_layout.cols * x / (maxx+1) )
             row = math.floor((model_layout.rows * y / maxy) - model_layout.top_offset)
+            # Ignore top_offset region #
+            if row < 0:
+                continue
             try:
                 button_pressed = model_layout.keys[row][col]
             except IndexError:


### PR DESCRIPTION
Fixes jumping to bottom row as user presses in the top offset region
Fixes '=' sign input when enabling numlock