### PR TITLE
ux582h fixes

### DIFF
--- a/asus_touchpad.py
+++ b/asus_touchpad.py
@@ -15,8 +15,8 @@ import libevdev.const
 from libevdev import EV_ABS, EV_KEY, EV_SYN, Device, InputEvent
 
 # Setup logging
-# LOG=DEBUG sudo -E ./asus-touchpad-numpad-driver  # all messages
-# LOG=ERROR sudo -E ./asus-touchpad-numpad-driver  # only error messages
+# LOG=DEBUG sudo -E ./asus_touchpad.py  # all messages
+# LOG=ERROR sudo -E ./asus_touchpad.py  # only error messages
 logging.basicConfig()
 log = logging.getLogger('Pad')
 log.setLevel(os.environ.get('LOG', 'INFO'))
@@ -266,7 +266,7 @@ while True:
                     deactivate_numlock()
                 continue
 
-            # Check if caclulator was hit #
+            # Check if calculator was hit #
             elif (x < 0.06 * maxx) and (y < 0.07 * maxy):
                 if numlock:
                     brightness = change_brightness(brightness)

--- a/asus_touchpad.py
+++ b/asus_touchpad.py
@@ -24,11 +24,11 @@ log.setLevel(os.environ.get('LOG', 'INFO'))
 
 # Select model from command line
 
-model = 'm433ia' # Model used in the derived script (with symbols)
+model = 'm433ia'  # Model used in the derived script (with symbols)
 if len(sys.argv) > 1:
     model = sys.argv[1]
 
-model_layout = importlib.import_module('numpad_layouts.'+ model)
+model_layout = importlib.import_module('numpad_layouts.' + model)
 
 # Figure out devices from devices file
 
@@ -48,21 +48,24 @@ while tries > 0:
         lines = f.readlines()
         for line in lines:
             # Look for the touchpad #
-            if touchpad_detected == 0 and ("Name=\"ASUE" in line or "Name=\"ELAN" in line) and "Touchpad" in line:
+            if touchpad_detected == 0 and "4F3:3101" in line and "Touchpad" in line:
                 touchpad_detected = 1
                 log.debug('Detect touchpad from %s', line.strip())
 
             if touchpad_detected == 1:
                 if "S: " in line:
                     # search device id
-                    device_id=re.sub(r".*i2c-(\d+)/.*$", r'\1', line).replace("\n", "")
-                    log.debug('Set touchpad device id %s from %s', device_id, line.strip())
+                    device_id = re.sub(r".*i2c-(\d+)/.*$",
+                                       r'\1', line).replace("\n", "")
+                    log.debug('Set touchpad device id %s from %s',
+                              device_id, line.strip())
 
                 if "H: " in line:
                     touchpad = line.split("event")[1]
                     touchpad = touchpad.split(" ")[0]
                     touchpad_detected = 2
-                    log.debug('Set touchpad id %s from %s', touchpad, line.strip())
+                    log.debug('Set touchpad id %s from %s',
+                              touchpad, line.strip())
 
             # Look for the keyboard (numlock) # AT Translated Set OR Asus Keyboard
             if keyboard_detected == 0 and ("Name=\"AT Translated Set 2 keyboard" in line or "Name=\"Asus Keyboard" in line):
@@ -74,7 +77,8 @@ while tries > 0:
                     keyboard = line.split("event")[1]
                     keyboard = keyboard.split(" ")[0]
                     keyboard_detected = 2
-                    log.debug('Set keyboard %s from %s', keyboard, line.strip())
+                    log.debug('Set keyboard %s from %s',
+                              keyboard, line.strip())
 
             # Stop looking if both have been found #
             if keyboard_detected == 2 and touchpad_detected == 2:
@@ -150,7 +154,9 @@ BRIGHT_VAL = [hex(val) for val in [31, 24, 1]]
 
 
 def activate_numlock(brightness):
-    numpad_cmd = "i2ctransfer -f -y " + device_id + " w13@0x15 0x05 0x00 0x3d 0x03 0x06 0x00 0x07 0x00 0x0d 0x14 0x03 " + BRIGHT_VAL[brightness] + " 0xad"
+    numpad_cmd = "i2ctransfer -f -y " + device_id + \
+        " w13@0x15 0x05 0x00 0x3d 0x03 0x06 0x00 0x07 0x00 0x0d 0x14 0x03 " + \
+        BRIGHT_VAL[brightness] + " 0xad"
     events = [
         InputEvent(EV_KEY.KEY_NUMLOCK, 1),
         InputEvent(EV_SYN.SYN_REPORT, 0)
@@ -161,7 +167,8 @@ def activate_numlock(brightness):
 
 
 def deactivate_numlock():
-    numpad_cmd = "i2ctransfer -f -y " + device_id + " w13@0x15 0x05 0x00 0x3d 0x03 0x06 0x00 0x07 0x00 0x0d 0x14 0x03 0x00 0xad"
+    numpad_cmd = "i2ctransfer -f -y " + device_id + \
+        " w13@0x15 0x05 0x00 0x3d 0x03 0x06 0x00 0x07 0x00 0x0d 0x14 0x03 0x00 0xad"
     events = [
         InputEvent(EV_KEY.KEY_NUMLOCK, 0),
         InputEvent(EV_SYN.SYN_REPORT, 0)
@@ -189,7 +196,9 @@ def launch_calculator():
 # status 3 = max bright
 def change_brightness(brightness):
     brightness = (brightness + 1) % len(BRIGHT_VAL)
-    numpad_cmd = "i2ctransfer -f -y " + device_id + " w13@0x15 0x05 0x00 0x3d 0x03 0x06 0x00 0x07 0x00 0x0d 0x14 0x03 " + BRIGHT_VAL[brightness] + " 0xad"
+    numpad_cmd = "i2ctransfer -f -y " + device_id + \
+        " w13@0x15 0x05 0x00 0x3d 0x03 0x06 0x00 0x07 0x00 0x0d 0x14 0x03 " + \
+        BRIGHT_VAL[brightness] + " 0xad"
     subprocess.call(numpad_cmd, shell=True)
     return brightness
 
@@ -270,8 +279,9 @@ while True:
                 continue
 
             # else numpad mode is activated
-            col = math.floor(model_layout.cols * x / (maxx+1) )
-            row = math.floor((model_layout.rows * y / maxy) - model_layout.top_offset)
+            col = math.floor(model_layout.cols * x / (maxx+1))
+            row = math.floor((model_layout.rows * y / maxy) -
+                             model_layout.top_offset)
             # Ignore top_offset region #
             if row < 0:
                 continue
@@ -279,9 +289,10 @@ while True:
                 button_pressed = model_layout.keys[row][col]
             except IndexError:
                 # skip invalid row and col values
-                log.debug('Unhandled col/row %d/%d for position %d-%d', col, row, x, y)
+                log.debug(
+                    'Unhandled col/row %d/%d for position %d-%d', col, row, x, y)
                 continue
-            
+
             if button_pressed == EV_KEY.KEY_5:
                 button_pressed = percentage_key
 

--- a/asus_touchpad.py
+++ b/asus_touchpad.py
@@ -99,6 +99,7 @@ while tries > 0:
 
     sleep(model_layout.try_sleep)
 
+
 # Start monitoring the touchpad
 
 try:

--- a/asus_touchpad.py
+++ b/asus_touchpad.py
@@ -101,7 +101,11 @@ while tries > 0:
 
 # Start monitoring the touchpad
 
-fd_t = open('/dev/input/event' + str(touchpad), 'rb')
+try:
+    fd_t = open('/dev/input/event' + str(touchpad), 'rb')
+except PermissionError:
+    log.error("Can't open /dev/input/event" + str(touchpad))
+    exit(1)
 fcntl(fd_t, F_SETFL, os.O_NONBLOCK)
 d_t = Device(fd_t)
 

--- a/asus_touchpad.service
+++ b/asus_touchpad.service
@@ -2,13 +2,14 @@
 Description=Asus Touchpad to Numpad Handler
 
 [Service]
-Type=simple
+Type=idle
 ExecStart=/usr/share/asus_touchpad_numpad-driver/asus_touchpad.py $LAYOUT $PERCENTAGE_KEY
 #StandardInput=tty-force
 StandardOutput=kmsg
 StandardError=kmsg
 TimeoutSec=5
 Restart=on-failure
+RestartSec=2
 # For some operating systems with boot failure, adding this following property might resolve the issue  
 # ExecStartPre=/bin/sleep 2
 

--- a/asus_touchpad.service
+++ b/asus_touchpad.service
@@ -4,9 +4,9 @@ Description=Asus Touchpad to Numpad Handler
 [Service]
 Type=simple
 ExecStart=/usr/share/asus_touchpad_numpad-driver/asus_touchpad.py $LAYOUT $PERCENTAGE_KEY
-StandardInput=tty-force
-StandardOutput=/var/log/asus_touchpad_numpad-driver/error.log
-StandardError=/var/log/asus_touchpad_numpad-driver/error.log
+#StandardInput=tty-force
+StandardOutput=kmsg
+StandardError=kmsg
 TimeoutSec=5
 Restart=on-failure
 # For some operating systems with boot failure, adding this following property might resolve the issue  

--- a/install.sh
+++ b/install.sh
@@ -115,7 +115,6 @@ echo "Add asus touchpad service in /etc/systemd/system/"
 cat asus_touchpad.service | LAYOUT=$model PERCENTAGE_KEY=$percentage_key envsubst '$LAYOUT $PERCENTAGE_KEY' > /etc/systemd/system/asus_touchpad_numpad.service
 
 mkdir -p /usr/share/asus_touchpad_numpad-driver/numpad_layouts
-mkdir -p /var/log/asus_touchpad_numpad-driver
 install asus_touchpad.py /usr/share/asus_touchpad_numpad-driver/
 install -t /usr/share/asus_touchpad_numpad-driver/numpad_layouts numpad_layouts/*.py
 

--- a/install.sh
+++ b/install.sh
@@ -24,7 +24,7 @@ then
 	exit 1
 fi
 
-interfaces=$(for i in $(i2cdetect -l | grep DesignWare | sed -r "s/^(i2c\-[0-9]+).*/\1/"); do echo $i; done)
+interfaces=$(for i in $(i2cdetect -l | grep DesignWare | sed -r "s/^(i2c\-[0-9]+).*/\1/"); do echo "$i"; done)
 if [ -z "$interfaces" ]
 then
     echo "No interface i2c found. Make sure you have installed libevdev packages"
@@ -34,7 +34,7 @@ fi
 touchpad_detected=false;
 for i in $interfaces; do
     echo -n "Testing interface $i : ";
-    number=$(echo -n $i | cut -d'-' -f2)
+    number=$(echo -n "$i" | cut -d'-' -f2)
 	offTouchpadCmd="i2ctransfer -f -y $number w13@0x15 0x05 0x00 0x3d 0x03 0x06 0x00 0x07 0x00 0x0d 0x14 0x03 0x00 0xad"
     i2c_test=$($offTouchpadCmd 2>&1)
     if [ -z "$i2c_test" ]

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -28,10 +28,10 @@ then
 	exit 1
 fi
 
-rm -f /lib/systemd/system/asus_touchpad_numpad.service
+rm -f /etc/systemd/system/asus_touchpad_numpad.service
 if [[ $? != 0 ]]
 then
-	echo "/lib/systemd/system/asus_touchpad_numpad.service cannot be removed correctly..."
+	echo "/etc/systemd/system/asus_touchpad_numpad.service cannot be removed correctly..."
 	exit 1
 fi
 

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -11,43 +11,42 @@ modprobe -r i2c-dev
 if [[ $? != 0 ]]
 then
 	echo "i2c-dev module cannot be removed successfuly..."
-	exit 1
+	# exit 1
 fi
 
 systemctl stop asus_touchpad_numpad
 if [[ $? != 0 ]]
 then
 	echo "asus_touchpad_numpad.service cannot be stopped correctly..."
-	exit 1
+	# exit 1
 fi
 
 systemctl disable asus_touchpad_numpad
 if [[ $? != 0 ]]
 then
 	echo "asus_touchpad_numpad.service cannot be disabled correctly..."
-	exit 1
+	# exit 1
 fi
 
 rm -f /etc/systemd/system/asus_touchpad_numpad.service
 if [[ $? != 0 ]]
 then
 	echo "/etc/systemd/system/asus_touchpad_numpad.service cannot be removed correctly..."
-	exit 1
+	# exit 1
 fi
 
 rm -rf /usr/share/asus_touchpad_numpad-driver/
 if [[ $? != 0 ]]
 then
 	echo "/usr/share/asus_touchpad_numpad-driver/ cannot be removed correctly..."
-	exit 1
+	# exit 1
 fi
 
 rm -rf /var/log/asus_touchpad_numpad-driver
 if [[ $? != 0 ]]
 then
 	echo "/var/log/asus_touchpad_numpad-driver cannot be removed correctly..."
-	exit 1
+	# exit 1
 fi
 
 echo "Asus touchpad python driver uninstalled"
-exit 0

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -42,11 +42,4 @@ then
 	# exit 1
 fi
 
-rm -rf /var/log/asus_touchpad_numpad-driver
-if [[ $? != 0 ]]
-then
-	echo "/var/log/asus_touchpad_numpad-driver cannot be removed correctly..."
-	# exit 1
-fi
-
 echo "Asus touchpad python driver uninstalled"


### PR DESCRIPTION
I had some trouble getting this running on my ux582h with Ubuntu 22.04, but succeeded at last.
Main differences are:
- touchpad detection https://github.com/mohamed-badaoui/asus-touchpad-numpad-driver/issues/87#issuecomment-1011181315
- change system service definition (type=idle and output to kmsg); should fix #93 
- ensure clean uninstall even if a single step failed