### PR TITLE
UM3402YA support and some changes in code, service and installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This is a python service which enables switching between numpad and touchpad for
 
 This python driver has been tested and works fine for these asus versions at the moment:
 - M433IA (with % and = symbols)
+- UM3402YA (with % and = symbols)
 - R424DA (without extra symbols)
 - ROG Strix G15 2021 
 - S413DA (with % and = symbols)

--- a/asus_touchpad.py
+++ b/asus_touchpad.py
@@ -191,7 +191,7 @@ def launch_calculator():
 def change_brightness(brightness):
     # If 4th argument is True then inverse change_brightness cycle
     if len(sys.argv) > 4:
-        if bool(sys.argv[4]): brightness = (brightness - 1) % len(BRIGHT_VAL)
+        if sys.argv[4] == True: brightness = (brightness - 1) % len(BRIGHT_VAL)
         else: brightness = (brightness + 1) % len(BRIGHT_VAL)
     else: brightness = (brightness + 1) % len(BRIGHT_VAL)
     numpad_cmd = f"i2ctransfer -f -y {device_id} w13@0x15 0x05 0x00 0x3d 0x03 0x06 0x00 0x07 0x00 0x0d 0x14 0x03 {BRIGHT_VAL[brightness]} 0xad"

--- a/asus_touchpad.py
+++ b/asus_touchpad.py
@@ -164,8 +164,6 @@ def activate_numlock(brightness):
             numpad_cmd_init = f"i2ctransfer -f -y {device_id} w13@0x15 0x05 0x00 0x3d 0x03 0x06 0x00 0x07 0x00 0x0d 0x14 0x03 {codes} 0xad"
             subprocess.call(numpad_cmd_init, shell=True)
     subprocess.call(numpad_cmd, shell=True)
-    print(f"Execute on: {numpad_cmd}")
-
 
 def deactivate_numlock():
     numpad_cmd = f"i2ctransfer -f -y {device_id} w13@0x15 0x05 0x00 0x3d 0x03 0x06 0x00 0x07 0x00 0x0d 0x14 0x03 0x00 0xad"
@@ -203,7 +201,6 @@ def change_brightness(brightness):
             numpad_cmd_init = f"i2ctransfer -f -y {device_id} w13@0x15 0x05 0x00 0x3d 0x03 0x06 0x00 0x07 0x00 0x0d 0x14 0x03 {codes} 0xad"
             subprocess.call(numpad_cmd_init, shell=True)
     subprocess.call(numpad_cmd, shell=True)
-    print(f"Execute brightness: {numpad_cmd}")
     return brightness
 
 

--- a/asus_touchpad.service
+++ b/asus_touchpad.service
@@ -3,7 +3,7 @@ Description=Asus Touchpad to Numpad Handler
 
 [Service]
 Type=simple
-ExecStart=/usr/share/asus_touchpad_numpad-driver/asus_touchpad.py $LAYOUT $PERCENTAGE_KEY
+ExecStart=/usr/share/asus_touchpad_numpad-driver/asus_touchpad.py $LAYOUT $PERCENTAGE_KEY $DEFAULT_LEVEL $INVERT_BRIGHTNESS_CYCLE
 StandardInput=tty-force
 StandardOutput=/var/log/asus_touchpad_numpad-driver/error.log
 StandardError=/var/log/asus_touchpad_numpad-driver/error.log

--- a/install.sh
+++ b/install.sh
@@ -80,6 +80,10 @@ do
             model=ux581l
             break
             ;;
+        "um3402ya" )
+            model=um3402ya
+            break
+            ;;
         "Q")
             exit 0
             ;;
@@ -110,9 +114,80 @@ do
     esac
 done
 
+echo
+echo "Select default brightness level:"
+PS3='Please enter your choice [1-4]: '
+options=("Low" "Medium" "High" "Quit")
+if [ "$model" != "um3402ya" ]; then
+	select opt in "${options[@]}"
+	do
+	    case $opt in
+	        "Low")
+	            default_level=0
+	     	    break
+	            ;;
+	        "Medium")
+	            default_level=1
+	            break
+	            ;;
+	        "High")
+	            default_level=2
+	            break
+	            ;;
+	        "Quit")
+	            exit 0
+	            ;;
+	        *) echo "invalid option $REPLY";;
+	    esac
+	done
+else
+	select opt in "${options[@]}"
+	do
+	    case $opt in
+	        "Low")
+	            default_level=1
+	     	    break
+	            ;;
+	        "Medium")
+	            default_level=4
+	            break
+	            ;;
+	        "High")
+	            default_level=8
+	            break
+	            ;;
+	        "Quit")
+	            exit 0
+	            ;;
+	        *) echo "invalid option $REPLY";;
+	    esac
+	done
+fi
+
+echo
+echo "How to change brightness?"
+PS3='Please enter your choice [1-3]: '
+options=("From low to high" "From high to low" "Quit")
+select opt in "${options[@]}"
+do
+    case $opt in
+        "From low to high")
+            invert_cycle="False"
+            break
+            ;;
+        "From high to low")
+            invert_cycle="True"
+            break
+            ;;
+        "Quit")
+            exit 0
+            ;;
+        *) echo "invalid option $REPLY";;
+    esac
+done
 
 echo "Add asus touchpad service in /etc/systemd/system/"
-cat asus_touchpad.service | LAYOUT=$model PERCENTAGE_KEY=$percentage_key envsubst '$LAYOUT $PERCENTAGE_KEY' > /etc/systemd/system/asus_touchpad_numpad.service
+cat asus_touchpad.service | LAYOUT=$model PERCENTAGE_KEY=$percentage_key envsubst '$LAYOUT $PERCENTAGE_KEY $DEFAULT_LEVEL $INVERT_BRIGHTNESS_CYCLE' > /etc/systemd/system/asus_touchpad_numpad.service
 
 mkdir -p /usr/share/asus_touchpad_numpad-driver/numpad_layouts
 mkdir -p /var/log/asus_touchpad_numpad-driver

--- a/install.sh
+++ b/install.sh
@@ -187,7 +187,7 @@ do
 done
 
 echo "Add asus touchpad service in /etc/systemd/system/"
-cat asus_touchpad.service | LAYOUT=$model PERCENTAGE_KEY=$percentage_key envsubst '$LAYOUT $PERCENTAGE_KEY $DEFAULT_LEVEL $INVERT_BRIGHTNESS_CYCLE' > /etc/systemd/system/asus_touchpad_numpad.service
+cat asus_touchpad.service | LAYOUT=$model PERCENTAGE_KEY=$percentage_key DEFAULT_LEVEL=$default_level INVERT_BRIGHTNESS_CYCLE=$invert_cycle envsubst '$LAYOUT $PERCENTAGE_KEY $DEFAULT_LEVEL $INVERT_BRIGHTNESS_CYCLE' > /etc/systemd/system/asus_touchpad_numpad.service
 
 mkdir -p /usr/share/asus_touchpad_numpad-driver/numpad_layouts
 mkdir -p /var/log/asus_touchpad_numpad-driver

--- a/numpad_layouts/gx701.py
+++ b/numpad_layouts/gx701.py
@@ -9,6 +9,9 @@ rows = 5
 # Subtract 0.3 (a third key) as the UX581L has about a third key space at the top
 top_offset = 0
 
+brightness_levels = ["0x01", "0x18", "0x1f"]
+brightness_init = []
+
 keys = [
     [EV_KEY.KEY_CALC, EV_KEY.KEY_KPSLASH, EV_KEY.KEY_KPASTERISK, EV_KEY.KEY_KPMINUS],
     [EV_KEY.KEY_KP7, EV_KEY.KEY_KP8, EV_KEY.KEY_KP9, EV_KEY.KEY_KPPLUS],

--- a/numpad_layouts/m433ia.py
+++ b/numpad_layouts/m433ia.py
@@ -8,6 +8,9 @@ cols = 5
 rows = 4
 top_offset = 0.3
 
+brightness_levels = ["0x01", "0x18", "0x1f"]
+brightness_init = []
+
 keys = [
     [EV_KEY.KEY_KP7, EV_KEY.KEY_KP8, EV_KEY.KEY_KP9, EV_KEY.KEY_KPSLASH, EV_KEY.KEY_BACKSPACE],
     [EV_KEY.KEY_KP4, EV_KEY.KEY_KP5, EV_KEY.KEY_KP6, EV_KEY.KEY_KPASTERISK, EV_KEY.KEY_BACKSPACE],

--- a/numpad_layouts/um3402ya.py
+++ b/numpad_layouts/um3402ya.py
@@ -1,0 +1,19 @@
+from libevdev import EV_KEY
+
+# Number of tries to identify the interface number
+try_times = 5
+try_sleep = 0.1
+
+cols = 5
+rows = 4
+top_offset = 0.3
+
+brightness_levels = ["0x00", "0x41", "0x42", "0x43", "0x44", "0x45", "0x46", "0x47", "0x48"]
+brightness_init = ["0x60", "0x01"]
+
+keys = [
+    [EV_KEY.KEY_KP7, EV_KEY.KEY_KP8, EV_KEY.KEY_KP9, EV_KEY.KEY_KPSLASH, EV_KEY.KEY_BACKSPACE],
+    [EV_KEY.KEY_KP4, EV_KEY.KEY_KP5, EV_KEY.KEY_KP6, EV_KEY.KEY_KPASTERISK, EV_KEY.KEY_BACKSPACE],
+    [EV_KEY.KEY_KP1, EV_KEY.KEY_KP2, EV_KEY.KEY_KP3, EV_KEY.KEY_KPMINUS, EV_KEY.KEY_5],
+    [EV_KEY.KEY_KP0, EV_KEY.KEY_KPDOT, EV_KEY.KEY_KPENTER, EV_KEY.KEY_KPPLUS, EV_KEY.KEY_KPEQUAL]
+]

--- a/numpad_layouts/ux433fa.py
+++ b/numpad_layouts/ux433fa.py
@@ -8,6 +8,9 @@ cols = 5
 rows = 4
 top_offset = 0.10
 
+brightness_levels = ["0x01", "0x18", "0x1f"]
+brightness_init = []
+
 keys = [
     [EV_KEY.KEY_KP7, EV_KEY.KEY_KP8, EV_KEY.KEY_KP9, EV_KEY.KEY_KPSLASH, EV_KEY.KEY_BACKSPACE],
     [EV_KEY.KEY_KP4, EV_KEY.KEY_KP5, EV_KEY.KEY_KP6, EV_KEY.KEY_KPASTERISK, EV_KEY.KEY_BACKSPACE],

--- a/numpad_layouts/ux581l.py
+++ b/numpad_layouts/ux581l.py
@@ -9,6 +9,9 @@ rows = 5 # Compared to the more "horizontal" version of the UM433DA (for example
 # Subtract 0.3 (a third key) as the UX581L has about a third key space at the top
 top_offset = 0.3
 
+brightness_levels = ["0x01", "0x18", "0x1f"]
+brightness_init = []
+
 keys = [
     [EV_KEY.KEY_KPEQUAL, EV_KEY.KEY_5, EV_KEY.KEY_BACKSPACE, EV_KEY.KEY_BACKSPACE],
     [EV_KEY.KEY_KP7, EV_KEY.KEY_KP8, EV_KEY.KEY_KP9, EV_KEY.KEY_KPSLASH],


### PR DESCRIPTION
Hi,
I updated the code a bit, adding support for the new model, as well as such features as setting default brightness level and inverting the brightness change cycle. Also moved the list of brightness levels to the layout files and added a list of initialization codes. Unfortunately, in my case the backlighting did not work at all in the original version. To turn it on, it was necessary to send first the initialization code, then the activation code and then the brightness level code.